### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,10 @@
         "node": true
     },
     "extends": [
-        "google"
+        "google",
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended"
     ],
     "globals": {
         "Atomics": "readonly",
@@ -19,5 +22,9 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "@typescript-eslint/no-use-before-define": "off",
+        "require-jsdoc": "off",
+        "sort-vars": "warn",
+        "padded-blocks": "off"
     }
 }


### PR DESCRIPTION
Added eslint:recommended and @typescript-eslint recommended to avoid incorrectly flagged imports

Rules added because of personal preference:

Change: "typescript-eslint/no-use-before-define": "off",
Reason:  avoids c-style headers / ordering

Change: "require-jsdoc": "off",
Reason: Obviously,

Change: "sort-vars": "warn",
Reason:  Compilation errors for unsorted variables might be a bit much sometimes

Change: "padded-blocks": "off"
Reason: sometimes a single line of padding can help with readability